### PR TITLE
add function to retrieve the ruleset file path

### DIFF
--- a/ruleset/rule.go
+++ b/ruleset/rule.go
@@ -353,6 +353,11 @@ func (m *MutableRuleSet) loadFilters(s adapter.RuleSet) {
 	m.filterMu.Unlock()
 }
 
+// RuleFilePath returns the path to the rule file.
+func (m *MutableRuleSet) RuleFilePath() string {
+	return m.ruleFile
+}
+
 // ruleWrapper wraps an [adapter.Rule] to allow checking if the rule is enabled before matching.
 type ruleWrapper struct {
 	// Rule is the underlying rule.


### PR DESCRIPTION
This pull request includes a small change to the `ruleset/rule.go` file. The change introduces a new method to the `MutableRuleSet` struct that returns the path to the rule file.

* [`ruleset/rule.go`](diffhunk://#diff-f52aa787ef478cb300a39c1122084404a68853d4db95a80fd380890294ab54d1R356-R360): Added the `RuleFilePath` method to the `MutableRuleSet` struct to return the path to the rule file.