### PR TITLE
Using amnezia constant

### DIFF
--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -22,13 +22,14 @@ import (
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
 
+	"github.com/getlantern/sing-box-extensions/constant"
 	"github.com/getlantern/sing-box-extensions/metrics"
 	"github.com/getlantern/sing-box-extensions/option"
 	"github.com/getlantern/sing-box-extensions/transport/amnezia"
 )
 
 func RegisterEndpoint(registry *endpoint.Registry) {
-	endpoint.Register[option.AmneziaWGEndpointOptions](registry, C.TypeWireGuard, NewEndpoint)
+	endpoint.Register[option.AmneziaWGEndpointOptions](registry, constant.TypeAmneziaWG, NewEndpoint)
 }
 
 var (

--- a/protocol/amnezia/outbound.go
+++ b/protocol/amnezia/outbound.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/netip"
 
+	"github.com/getlantern/sing-box-extensions/constant"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/outbound"
 	"github.com/sagernet/sing-box/common/dialer"
@@ -44,7 +45,7 @@ import (
 )
 
 func RegisterOutbound(registry *outbound.Registry) {
-	outbound.Register[option.LegacyWireGuardOutboundOptions](registry, C.TypeWireGuard, NewOutbound)
+	outbound.Register[option.LegacyWireGuardOutboundOptions](registry, constant.TypeAmneziaWG, NewOutbound)
 }
 
 var (

--- a/protocol/amnezia/outbound.go
+++ b/protocol/amnezia/outbound.go
@@ -147,11 +147,6 @@ func (o *Outbound) Close() error {
 	return o.endpoint.Close()
 }
 
-func (o *Outbound) InterfaceUpdated() {
-	o.endpoint.BindUpdate()
-	return
-}
-
 func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
 	switch network {
 	case N.NetworkTCP:


### PR DESCRIPTION
Currently if we try to use sing-box-extensions for a wireguard client, it tries to use the amnezia instead and this causes a panic on the executable. Using the correct constant per protocol should fix this issue