### PR TITLE
refactor(amnezia): rename AmneziaWG to Amnezia

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -1,8 +1,8 @@
 package constant
 
 const (
-	TypeAmneziaWG = "amneziawg"
-	TypeALGeneva  = "algeneva"
-	TypeOutline   = "outline"
-	TypeWATER     = "water"
+	TypeAmnezia  = "amnezia"
+	TypeALGeneva = "algeneva"
+	TypeOutline  = "outline"
+	TypeWATER    = "water"
 )

--- a/option/amnezia.go
+++ b/option/amnezia.go
@@ -5,15 +5,15 @@ import (
 )
 
 /*
-AmneziaOptions provides advanced security options for WireGuard required to activate AmneziaWG.
+AmneziaOptions provides advanced security options for WireGuard required to activate Amnezia.
 
-In AmneziaWG, random bytes are appended to every auth packet to alter their size.
+In Amnezia, random bytes are appended to every auth packet to alter their size.
 
 Thus, "init and response handshake packets" have added "junk" at the beginning of their data, the size of which
 is determined by the values S1 and S2.
 
 By default, the initiating handshake packet has a fixed size (148 bytes). After adding the junk, its size becomes 148 bytes + S1.
-AmneziaWG also incorporates another trick for more reliable masking. Before initiating a session, Amnezia sends a
+Amnezia also incorporates another trick for more reliable masking. Before initiating a session, Amnezia sends a
 
 certain number of "junk" packets to thoroughly confuse DPI systems. The number of these packets and their
 minimum and maximum byte sizes can also be adjusted in the settings, using parameters Jc, Jmin, and Jmax.
@@ -32,7 +32,7 @@ type AmneziaOptions struct {
 	TransportPacketMagicHeader uint32 `json:"transport_packet_magic_header,omitempty"` // h4
 }
 
-type AmneziaWGEndpointOptions struct {
+type AmneziaEndpointOptions struct {
 	O.WireGuardEndpointOptions
 	AmneziaOptions
 }

--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -28,7 +28,7 @@ import (
 )
 
 func RegisterEndpoint(registry *endpoint.Registry) {
-	endpoint.Register[option.AmneziaWGEndpointOptions](registry, C.TypeWireGuard, NewEndpoint)
+	endpoint.Register[option.AmneziaEndpointOptions](registry, C.TypeWireGuard, NewEndpoint)
 }
 
 var (
@@ -45,7 +45,7 @@ type Endpoint struct {
 	endpoint       *amnezia.Endpoint
 }
 
-func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AmneziaWGEndpointOptions) (adapter.Endpoint, error) {
+func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AmneziaEndpointOptions) (adapter.Endpoint, error) {
 	ep := &Endpoint{
 		Adapter:        endpoint.NewAdapterWithDialerOptions(C.TypeWireGuard, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
 		ctx:            ctx,

--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -48,7 +48,7 @@ type Endpoint struct {
 
 func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AmneziaEndpointOptions) (adapter.Endpoint, error) {
 	ep := &Endpoint{
-		Adapter:        endpoint.NewAdapterWithDialerOptions(C.TypeWireGuard, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
+		Adapter:        endpoint.NewAdapterWithDialerOptions(constant.TypeAmnezia, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
 		ctx:            ctx,
 		router:         router,
 		logger:         logger,

--- a/protocol/amnezia/outbound.go
+++ b/protocol/amnezia/outbound.go
@@ -1,6 +1,6 @@
-// Package amnezia implements the AmneziaWG dialer outbound.
+// Package amnezia implements the Amnezia dialer outbound.
 /*
-To activate advanced security mode for WireGuard (powered by AmneziaWG), please add the following
+To activate advanced security mode for WireGuard (powered by Amnezia), please add the following
 fields to the configuration:
 
 {


### PR DESCRIPTION
This PR renames `AmneziaWG` to `Amnezia` for consistency. 