### PR TITLE
add fallback outbound adapter

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -6,3 +6,7 @@ const (
 	TypeOutline  = "outline"
 	TypeWATER    = "water"
 )
+
+const (
+	TypeFallback = "fallback"
+)

--- a/option/group.go
+++ b/option/group.go
@@ -1,0 +1,7 @@
+package option
+
+type FallBackOutboundOptions struct {
+	// Primary and Fallback are the tags of the primary and fallback outbounds.
+	Primary  string `json:"main,omitempty"`
+	Fallback string `json:"fallback,omitempty"`
+}

--- a/protocol/group/fallback.go
+++ b/protocol/group/fallback.go
@@ -1,0 +1,115 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/logger"
+	"github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/service"
+
+	"github.com/getlantern/sing-box-extensions/constant"
+	"github.com/getlantern/sing-box-extensions/option"
+)
+
+func RegisterFallback(registry *outbound.Registry) {
+	outbound.Register[option.FallBackOutboundOptions](registry, constant.TypeFallback, NewFallback)
+}
+
+// Fallback is an outbound adapter that attempts to use a primary outbound, and falls back to a
+// secondary outbound if the primary fails.
+type Fallback struct {
+	outbound.Adapter
+	ctx         context.Context
+	outbound    adapter.OutboundManager
+	logger      logger.ContextLogger
+	primaryTag  string
+	fallbackTag string
+}
+
+// NewFallback creates a new Fallback outbound adapter.
+func NewFallback(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.FallBackOutboundOptions) (adapter.Outbound, error) {
+	if options.Primary == "" {
+		return nil, errors.New("missing primary outbound tag")
+	}
+	if options.Fallback == "" {
+		return nil, errors.New("missing fallback outbound tag")
+	}
+	if options.Primary == options.Fallback {
+		return nil, fmt.Errorf("primary and fallback outbound tags cannot be the same: %s", options.Primary)
+	}
+
+	outbounds := []string{options.Primary, options.Fallback}
+	return &Fallback{
+		Adapter:     outbound.NewAdapter(constant.TypeFallback, tag, nil, outbounds),
+		ctx:         ctx,
+		outbound:    service.FromContext[adapter.OutboundManager](ctx),
+		logger:      logger,
+		primaryTag:  options.Primary,
+		fallbackTag: options.Fallback,
+	}, nil
+}
+
+// Start checks that both the primary and fallback outbounds are available.
+func (d *Fallback) Start() error {
+	if _, loaded := d.outbound.Outbound(d.primaryTag); !loaded {
+		return fmt.Errorf("missing primary outbound %s", d.primaryTag)
+	}
+	if _, loaded := d.outbound.Outbound(d.fallbackTag); !loaded {
+		return fmt.Errorf("missing fallback outbound %s", d.fallbackTag)
+	}
+	return nil
+}
+
+// DialContext attempts to dial using the primary outbound. If it fails, it falls back to the
+// fallback outbound.
+func (d *Fallback) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
+	outbound, loaded := d.outbound.Outbound(d.primaryTag)
+	if !loaded {
+		return nil, fmt.Errorf("primary outbound %s not found", d.primaryTag)
+	}
+	conn, err := outbound.DialContext(ctx, network, destination)
+	if err == nil {
+		return conn, nil
+	}
+
+	d.logger.Error("dial on primary outbound: ", err)
+	outbound, loaded = d.outbound.Outbound(d.fallbackTag)
+	if !loaded {
+		return nil, fmt.Errorf("fallback outbound %s not found", d.fallbackTag)
+	}
+	fallbackConn, err := outbound.DialContext(ctx, network, destination)
+	if err != nil {
+		return nil, fmt.Errorf("dial on fallback outbound: %w", err)
+	}
+	return fallbackConn, nil
+}
+
+// ListenPacket attempts to create a packet connection using the primary outbound. If it fails, it
+// falls back to the fallback outbound.
+func (d *Fallback) ListenPacket(ctx context.Context, destination metadata.Socksaddr) (net.PacketConn, error) {
+	outbound, loaded := d.outbound.Outbound(d.primaryTag)
+	if !loaded {
+		return nil, fmt.Errorf("primary outbound %s not found", d.primaryTag)
+	}
+	conn, err := outbound.ListenPacket(ctx, destination)
+	if err == nil {
+		return conn, nil
+	}
+
+	d.logger.Error("packet connection on primary outbound: ", err)
+	outbound, loaded = d.outbound.Outbound(d.fallbackTag)
+	if !loaded {
+		return nil, fmt.Errorf("fallback outbound %s not found", d.fallbackTag)
+	}
+	fallbackConn, err := outbound.ListenPacket(ctx, destination)
+	if err != nil {
+		return nil, fmt.Errorf("packet connection on fallback outbound: %w", err)
+	}
+	return fallbackConn, nil
+}

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sagernet/sing-box/include"
 
 	"github.com/getlantern/sing-box-extensions/protocol/amnezia"
+	"github.com/getlantern/sing-box-extensions/protocol/group"
 
 	"github.com/getlantern/sing-box-extensions/protocol/algeneva"
 	"github.com/getlantern/sing-box-extensions/protocol/outline"
@@ -53,9 +54,13 @@ func registerInbounds(registry *inbound.Registry) {
 }
 
 func registerOutbounds(registry *outbound.Registry) {
+	// custom protocol outbounds
 	algeneva.RegisterOutbound(registry)
 	outline.RegisterOutbound(registry)
 	amnezia.RegisterOutbound(registry)
+
+	// utility outbounds
+	group.RegisterFallback(registry)
 }
 
 func registerEndpoints(registry *endpoint.Registry) {


### PR DESCRIPTION
This pull request introduces a new "fallback" outbound adapter that provides failover functionality, allowing a secondary outbound to be used if the primary outbound fails. 

### Fallback Outbound Adapter Implementation:

* [`protocol/group/fallback.go`](diffhunk://#diff-af73076071d6208b7d5f01830ab34e4b0a612178d7107ae891032e78dd2d5b7dR1-R115): Added the implementation of the `Fallback` outbound adapter, which attempts to use a primary outbound and falls back to a secondary outbound if the primary fails. This includes methods for dialing, listening for packets, and validating the availability of both outbounds.