### PR TITLE
feat(context): add BoxContext to retreive a base ctx with registries

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,15 @@
+package sbx
+
+import (
+	"context"
+
+	box "github.com/sagernet/sing-box"
+
+	"github.com/getlantern/sing-box-extensions/protocol"
+)
+
+// BoxContext returns a box context with the registered inbound, outbound, and endpoint protocols.
+func BoxContext() context.Context {
+	in, out, ep := protocol.GetRegistries()
+	return box.Context(context.Background(), in, out, ep)
+}


### PR DESCRIPTION
This pull request introduces a new utility function, `BoxContext`, in the `context.go` file to streamline the creation of a `box` context with registered protocols.

### New functionality:
* [`context.go`](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253R1-R15): Added the `BoxContext` function, which initializes a `box` context using the inbound, outbound, and endpoint protocol registries retrieved from `protocol.GetRegistries()`. This simplifies the process of creating a context for `sing-box` operations.