### PR TITLE
fix log source values to point to correct caller for non-context methods

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -121,7 +121,7 @@ type slogLogger struct {
 	tag string
 }
 
-// Log accpets a [sing-box/log.Level] to satisfy the [log.ContextLogger] interface. It is converted
+// Log accepts a [sing-box/log.Level] to satisfy the [log.ContextLogger] interface. It is converted
 // to [slog.Level] internally.
 func (l *slogLogger) Log(ctx context.Context, level log.Level, args ...any) string {
 	if len(args) == 0 {


### PR DESCRIPTION
This fixes an issue where calling the non-context log methods would result in the log source value to point to that method instead of it's caller.