### PR TITLE
log urltest outbound delays

### DIFF
--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -475,9 +475,11 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 			g.logger.Trace("checking outbound", "tag", realTag)
 			t, err := urltest.URLTest(testCtx, g.url, p)
 			if err != nil {
+				g.logger.Debug("outbound unavailable", "tag", realTag, "error", err)
 				g.history.DeleteURLTestHistory(realTag)
 				return nil, nil
 			}
+			g.logger.Debug("outbound available", "tag", realTag, "delay_ms", t)
 			g.history.StoreURLTestHistory(realTag, &urltest.History{
 				Time:  time.Now(),
 				Delay: t,


### PR DESCRIPTION
This pull request adds additional debug logging to the `urlTest` method in `protocol/group/mutableurltest.go` to improve visibility into outbound connection availability and errors.

Logging improvements:

* Added a debug log when an outbound is unavailable, including the error and tag for easier troubleshooting.
* Added a debug log when an outbound is available, reporting the tag and measured delay for better monitoring.